### PR TITLE
Fix bash scripts not running with positional arguments

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -44,7 +44,7 @@ if [ ! -f $mark ]; then
   pip install -r requirements.txt || exit 1
   touch $mark
 fi
-echo "if [ \$(which python) != $venv_dir/bin/python ]; then source $venv_dir/bin/activate; fi" > env.sh
+echo "if [ \$(which python) != $venv_dir/bin/python ]; then source $venv_dir/bin/activate base; fi" > env.sh
 
 mark=.done-kaldi-tools
 if [ ! -f $mark ]; then


### PR DESCRIPTION
For example, if I run `baseline/run.sh --stage 10`, I will get this message:
```
activate does not accept more than one argument:
['--stage', '10']
```
By using `source activate base` instead of `source activate`, conda will not consume positional arguments given to the main script, and this error will go away (relevant issue https://github.com/conda/conda/issues/2965).